### PR TITLE
Add GitHub issue templates and bot for auto label assignment

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,62 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: 🐞 Bug Report 
+description: File a bug report
+title: "[Bug]: "
+labels: [Type/Bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector you are reporting the bug against
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/02_documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_documentation_issue.yml
@@ -1,0 +1,59 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: 📖 Doc Issue/Improvement Report 
+description: File a documentation issue/improvement
+title: "[Docs]: "
+labels: [Type/Docs]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to improve our docs!
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector you are reporting the documentation issue/improvement against
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Documentation Issue/Improvement
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Relevant suggestions
+      description: If you are suggesting a text as the solution please specify below

--- a/.github/ISSUE_TEMPLATE/03_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/03_improvement.yml
@@ -1,0 +1,56 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: 🤔 Improvement Request 
+description: Create an improvement request for an existing feature
+title: "[Improvement]: "
+labels: [Type/Improvement]
+body:
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector you are suggesting improvement for
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: improvement-request
+    attributes:
+      label: Suggested improvement
+    validations:
+      required: true
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related issues
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear and concise description of what the problem is.
+      value: "I am trying to do [...] but [...]"

--- a/.github/ISSUE_TEMPLATE/04_new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/04_new_feature.yml
@@ -1,0 +1,58 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: 💡 New Feature Request
+description: Create a new feature request
+title: "[Feature]: "
+labels: [Type/New Feature]
+body:
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector you are suggesting new feature for
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: Suggested feature
+      description: Describe the feature you'd like
+      placeholder: A clear and concise description of what you want to happen. Include any alternative solutions you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: related-issues
+    attributes:
+      label: Related issues
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear and concise description of what the problem is.
+      value: "I am trying to do [...] but [...]"

--- a/.github/ISSUE_TEMPLATE/05_new_epic.yml
+++ b/.github/ISSUE_TEMPLATE/05_new_epic.yml
@@ -1,0 +1,60 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: 🌱 New Epic
+description: Create a new epic
+title: "[Epic]: "
+labels: [Type/Epic]
+body:
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector your epic is related to (choose other if it is not)
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: epic-description
+    attributes:
+      label: Epic description
+      description: Describe the epic
+      placeholder: A clear and concise description of what is the epic.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Related tasks
+      description: Mention the tasks related to the epic
+      value: "- [ ] **Task1** 
+              - [ ] **Task2** "
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/06_new_task.yml
+++ b/.github/ISSUE_TEMPLATE/06_new_task.yml
@@ -1,0 +1,52 @@
+# pls refer https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: ✍️ New Task
+description: Create a new task
+title: "[Task]: "
+labels: [Type/Task]
+body:
+  - type: dropdown
+    id: Connector-name
+    attributes:
+      label: Connector Name
+      description: Choose the connector your task is related to (choose other if it is not)
+      options:
+        - connectors/openapi (Open API Connector)
+        - module/aws-s3 (AWS S3)
+        - module/aws-sqs (AWS SQS)
+        - module/azure-ad (Azure Active Directory)
+        - module/azure-eventhub (Azure Event Hub)
+        - module/azure-servicebus (Azure Servicebus)
+        - module/azure-storageservice (Azure Blob & Storage Service)
+        - module/cosmosdb (Cosmos DB)
+        - module/gcalendar (Google Calendar)
+        - module/gdrive (Google Drive)
+        - module/github (Github)
+        - module/gmail (Gmail)
+        - module/google-peopleapi (People API)
+        - module/gsheet (Google Sheet)
+        - module/microsoft-excel (MS Excel)
+        - module/microsoft-onedrive (MS OneDrive)
+        - module/microsoft-onenote (MS OneNote)
+        - module/microsoft-teams (MS Teams)
+        - module/mongodb (Mongo DB)
+        - module/netsuite (Netsuite)
+        - module/outlook-calendar (Outlook Calendar)
+        - module/outlook-mail (Outlook Mail)
+        - module/redis (Redis)
+        - module/salesforce (Salesforce)
+        - module/slack (Slack)
+        - module/snowflake (SnowFlake)
+        - module/twilio (Twilio)
+        - module/twitter (Twitter)
+        - other (None Listed Above)
+    validations:
+      required: true
+  - type: textarea
+    id: task-description
+    attributes:
+      label: Task Description
+      description: Describe the task to be performed 
+      placeholder: A clear and concise description of what needs to be done. Specify a scope if relevent.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with Open API to Ballerina Generator Tool
+    url:  https://github.com/ballerina-platform/ballerina-openapi/issues/new/choose
+    about: Please open issues relating to the API to Ballerina Generator Tool.

--- a/.github/workflows/add_connector_label.yml
+++ b/.github/workflows/add_connector_label.yml
@@ -1,0 +1,30 @@
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            var body = context.payload.issue.body
+            var words = body.split(" ");
+            console.log(words)
+            for (var i = 0; i < words.length - 1; i++) {
+                var word = words[i]
+                if(word.startsWith('Name\n\nmodule/') | word.startsWith('Name\n\nconnectors/')) {
+                    var label = word.substring(6) 
+                    console.log(label)
+                    github.issues.addLabels({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: [label]
+                     })
+                    break 
+                }
+            }
+
+


### PR DESCRIPTION
## Purpose

This PR is to add following templates for issues 

1. Bug report
2. Feature request
3. Improvement request
4. Documentation issue/improvement
5. Task
6. Epic

Also it contains a github action to auto assign label to issues - separating them out to relevant connector. 