### PR TITLE
Update Slack to Discord in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ballerina code is distributed under [Apache license 2.0](https://github.com/ball
 
 ## Useful links
 
-* Chat live with us on our [Slack channel](https://ballerina.io/community/slack/).
+* Chat live with us on our [Discord server](https://discord.gg/ballerinalang).
 * Technical questions should be posted on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.
 * Ballerina performance test results are available [here](performance/benchmarks/summary.md).
 


### PR DESCRIPTION
## Purpose
Update Readme.md pointing to Discord rather Slack 

